### PR TITLE
add second run of script in new-generation mode to include more index…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -301,7 +301,7 @@ pipeline {
 			// Get into S3, cohabitating safely with TTL.
 			withCredentials([string(credentialsId: 'aws_go_access_key', variable: 'AWS_ACCESS_KEY_ID'), string(credentialsId: 'aws_go_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {
 			    sh 'aws s3 cp ./metadata.json s3://go-data-product-live-go-cam/product/json/provider-to-model.json'
-			    sh 'aws s3 cp ../ s3://go-data-product-live-go-cam/product/json/ --recursive --exclude "*" --include "index-*.json"'
+			    sh 'aws s3 cp ../ s3://go-data-product-live-go-cam/product/json/ --recursive --exclude "*" --include "*_index.json"'
 			}
 		    }
 		}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,10 +296,12 @@ pipeline {
 			dir('./jsonout') {
 			    sh 'wget -N https://raw.githubusercontent.com/geneontology/go-site/$TARGET_GO_SITE_BRANCH/scripts/gen-model-meta.py'
 			    sh 'python3 gen-model-meta.py > ../metadata.json'
+			    sh 'python3 gen-model-meta.py --keys-to-index contributor --keys-to-index providedBy --keys-to-index source --keys-to-index evidence --keys-to-index entity --output-dir ../'
 			}
 			// Get into S3, cohabitating safely with TTL.
 			withCredentials([string(credentialsId: 'aws_go_access_key', variable: 'AWS_ACCESS_KEY_ID'), string(credentialsId: 'aws_go_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {
 			    sh 'aws s3 cp ./metadata.json s3://go-data-product-live-go-cam/product/json/provider-to-model.json'
+			    sh 'aws s3 cp ../ s3://go-data-product-live-go-cam/product/json/ --recursive --exclude "*" --include "index-*.json"'
 			}
 		    }
 		}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,7 +296,7 @@ pipeline {
 			dir('./jsonout') {
 			    sh 'wget -N https://raw.githubusercontent.com/geneontology/go-site/$TARGET_GO_SITE_BRANCH/scripts/gen-model-meta.py'
 			    sh 'python3 gen-model-meta.py > ../metadata.json'
-			    sh 'python3 gen-model-meta.py --keys-to-index contributor --keys-to-index providedBy --keys-to-index source --keys-to-index evidence --keys-to-index entity --output-dir ../'
+			    sh 'python3 gen-model-meta.py --keys-to-index taxon --keys-to-index contributor --keys-to-index providedBy --keys-to-index source --keys-to-index evidence --keys-to-index entity --output-dir ../'
 			}
 			// Get into S3, cohabitating safely with TTL.
 			withCredentials([string(credentialsId: 'aws_go_access_key', variable: 'AWS_ACCESS_KEY_ID'), string(credentialsId: 'aws_go_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {


### PR DESCRIPTION
… files in addition to the existing prod index file, provider-to-model.json
see https://github.com/geneontology/go-site/pull/2423 for more details.

Note: this PR can't be merged until the PR above is merged into `master` in the go-site repo (else the new command added here won't be found and this runner will fail). 

