### PR TITLE
Cap oaklib<0.7 to unbreak the gocam-py YAML stage dependency install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -353,7 +353,11 @@ pipeline {
 		    sh "mkdir -p /opt/models"
 
 		    // Setup necessary libs and code.
-		    sh "cd /opt/go-site/scripts && pip install -r requirements.txt"
+		    // Cap oaklib below 0.7: 0.7 added `llm` as a core dep,
+		    // which cascades a resolver backtrack into an ancient
+		    // fastobo sdist that no longer builds (setuptools-rust
+		    // API removed). See geneontology/pipeline-raw-go-cam#12.
+		    sh "cd /opt/go-site/scripts && pip install 'oaklib<0.7' -r requirements.txt"
 		    sh "pip install awscli"
 
 		    // Pull saved models into our environment from


### PR DESCRIPTION
Unblocks the nightly `pipeline-raw-go-cam` build, red since #269 (2026-07-02). **First step toward geneontology/operations#88** — this only gets the build green again; the durable, cross-pipeline fix stays tracked in that issue. Deliberately not "Fixes", so merging won't close the broader issue.

**What broke:** the "Produce gocam-py YAML" stage runs `pip install -r go-site/scripts/requirements.txt` live from PyPI, and that file pins `oaklib>=0.6.18` with no upper bound. **oaklib 0.7.x (released 2026-07-02)** added `llm` as a core dependency, which cascades a pip resolver backtrack (via a `chardet<5` conflict with modern `pronto`) down to the sdist-only `fastobo 0.10.2.post1`. That old sdist can't build against current `setuptools-rust` (`ModuleNotFoundError: No module named 'setuptools_rust.utils'`), so the stage dies.

**This change:** adds `'oaklib<0.7'` to the stage's `pip install`, which merges with the requirements pin to `>=0.6.18,<0.7` and restores the exact known-good stack from the last green run #268 (oaklib 0.6.23 / pronto 2.7.3 / fastobo 0.14.1; no `llm`).

**Note:** because it's a `Jenkinsfile` change, it takes effect via "Scan Repository Now" (a fresh full build), not Restart-from-Stage.

_— Posted by Claude Code agent on behalf of @kltm._