### PR TITLE
Drop inline oaklib<0.7 cap now that go-site pins it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -353,11 +353,7 @@ pipeline {
 		    sh "mkdir -p /opt/models"
 
 		    // Setup necessary libs and code.
-		    // Cap oaklib below 0.7: 0.7 added `llm` as a core dep,
-		    // which cascades a resolver backtrack into an ancient
-		    // fastobo sdist that no longer builds (setuptools-rust
-		    // API removed). See geneontology/pipeline-raw-go-cam#12.
-		    sh "cd /opt/go-site/scripts && pip install 'oaklib<0.7' -r requirements.txt"
+		    sh "cd /opt/go-site/scripts && pip install -r requirements.txt"
 		    sh "pip install awscli"
 
 		    // Pull saved models into our environment from


### PR DESCRIPTION
Removes the repo-local `oaklib<0.7` cap added in #13. The gocam-py YAML stage clones go-site master at runtime, and go-site#2714 now caps `oaklib<0.7` in `scripts/requirements.txt`, so the Jenkinsfile-local cap is redundant — reverting to the plain install keeps a single upstream source of truth.

Tracking: geneontology/operations#88.

_— Posted by Claude Code agent on behalf of @kltm._